### PR TITLE
Cost Center pageSize set to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Cost Center pageSize set to 100
+
 ### Removed
 - [ENGINEERS-1247] - Disable cypress tests in PR level
 

--- a/react/components/customers-admin.tsx
+++ b/react/components/customers-admin.tsx
@@ -444,6 +444,7 @@ const UserEdit: FC<any> = (props: any) => {
                           getCostCenter({
                             variables: {
                               id: event.value,
+                              pageSize: 100,
                             },
                           })
                         }}


### PR DESCRIPTION
When using B2B Customer Admin to add a user, the Cost Center dropdown defaults to 25 with no way to choose a cost center past the first 25.
![image](https://github.com/vtex-apps/storefront-permissions-components/assets/47258865/a79e1fe3-93c2-49b0-a1e2-8c0837732842)
