### PR TITLE
Fix/show more 25 options at organizations auto complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- shows more options in the organization dropdown
+
 ### Removed
 - [ENGINEERS-1247] - Disable cypress tests in PR level
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- shows more options in the organization dropdown
+### Fixed
+- shows more options in the cost centers dropdown
 
 ### Removed
 - [ENGINEERS-1247] - Disable cypress tests in PR level

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -11,7 +11,7 @@ const initialState = {
   status: ['active', 'on-hold', 'inactive'],
   search: '',
   page: 1,
-  pageSize: 9999,
+  pageSize: 999,
   sortOrder: 'ASC',
   sortedBy: 'name',
 }

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -11,7 +11,7 @@ const initialState = {
   status: ['active', 'on-hold', 'inactive'],
   search: '',
   page: 1,
-  pageSize: 25,
+  pageSize: 9999,
   sortOrder: 'ASC',
   sortedBy: 'name',
 }
@@ -78,7 +78,7 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
   }, [data])
 
   useEffect(() => {
-    if (term && term.length > 2) {
+    if (term && term.length > 0) {
       setHasChanged(true)
       refetch({
         ...initialState,

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -11,7 +11,7 @@ const initialState = {
   status: ['active', 'on-hold', 'inactive'],
   search: '',
   page: 1,
-  pageSize: 999,
+  pageSize: 500,
   sortOrder: 'ASC',
   sortedBy: 'name',
 }

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -78,7 +78,7 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
   }, [data])
 
   useEffect(() => {
-    if (term && term.length > 0) {
+    if (term && term.length > 1) {
       setHasChanged(true)
       refetch({
         ...initialState,


### PR DESCRIPTION
#### What problem is this solving?
Before, it was not possible to show more than 25 options at the dropdown organization

<!--- What is the motivation and context for this change? -->
This change might be motivated by experience from user, enabling a better visualization of organizations

#### How to test it?
In the admin panel, follow these navigation steps:

1. Select the "Applications" menu.
2. From the opened menu, select "B2B Customers."
3. Add a new customer.
4. Field the access profile.
5. Select the organization.

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://josmarjr--b2bstore005.myvtex.com/admin/b2b-customers)

#### Screenshots or example usage:
<img width="1440" alt="Screenshot 2024-07-25 at 10 39 21" src="https://github.com/user-attachments/assets/25b4ed4e-b28c-4e0d-a7c2-5cefcf9aec3a">

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
