### PR TITLE
Fix/implement cost center autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Run schedule job only on saturday
+
 ### Removed
 - [ENGINEERS-1247] - Disable cypress tests in PR level
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Implement cost center autocomplete, lazyload in organization autocomplete and maxHeight prop
 
-### Fixed
-
-- Run schedule job only on saturday
-
 ## [0.3.2] - 2024-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Run schedule job only on saturday
-=======
+
 ## [0.3.2] - 2024-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Implement cost center autocomplete and lazyload in organization autocomplete
+- Implement cost center autocomplete, lazyload in organization autocomplete and maxHeight prop
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Implement cost center autocomplete and lazyload in organization autocomplete
+
+### Fixed
+
 - Run schedule job only on saturday
 
 ### Removed

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl'
 
 import { messages } from './customers-admin'
 import GET_COST_CENTER_BY_ORG from '../queries/costCentersByOrg.gql'
+import { SEARCH_TERM_DELAY_MS } from '../constants/debounceDelay'
 
 interface Props {
   onChange: (value: { value: string | null; label: string }) => void
@@ -43,7 +44,7 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
   useEffect(() => {
     const handler = setTimeout(() => {
       setDebouncedSearchTerm(costCenterTextInput)
-    }, 500) // 500ms delay
+    }, SEARCH_TERM_DELAY_MS) // 500ms delay
 
     return () => {
       clearTimeout(handler)

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react'
+import { useQuery } from 'react-apollo'
+import { AutocompleteInput } from 'vtex.styleguide'
+import { useIntl } from 'react-intl'
+
+import { messages } from './customers-admin'
+import GET_COST from '../queries/costCentersByOrg.gql'
+
+interface Props {
+  onChange: (value: { value: string | null; label: string }) => void
+  organizationId?: string
+}
+
+const initialState = {
+  search: '',
+  page: 1,
+  pageSize: 25,
+  sortOrder: 'ASC',
+  sortedBy: 'name',
+}
+
+const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
+  const { formatMessage } = useIntl()
+  const [costCenterTextInput, setCostCenterTextInput] = useState('')
+  const [debouncedSearchTerm, setDebouncedSearchTerm] =
+    useState(costCenterTextInput)
+
+  const { data, loading, refetch } = useQuery(GET_COST, {
+    variables: {
+      ...initialState,
+      id: organizationId,
+    },
+    ssr: false,
+    notifyOnNetworkStatusChange: true,
+    skip: !organizationId,
+  })
+
+  const onClear = () => {
+    setCostCenterTextInput('')
+    onChange({ value: null, label: '' })
+  }
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedSearchTerm(costCenterTextInput)
+    }, 500) // 500ms delay
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [costCenterTextInput])
+
+  useEffect(() => {
+    if (debouncedSearchTerm) {
+      refetch({
+        ...initialState,
+        id: organizationId,
+        search: debouncedSearchTerm,
+      })
+    } else if (debouncedSearchTerm === '') {
+      onClear()
+    }
+  }, [debouncedSearchTerm])
+
+  const options = {
+    onSelect: onChange,
+    loading,
+    value: data?.getCostCentersByOrganizationId?.data?.map(
+      (costCenter: { id: string; name: string }) => ({
+        value: costCenter.id,
+        label: costCenter.name,
+      })
+    ),
+  }
+
+  const input = {
+    onChange: (_term: string) => {
+      setCostCenterTextInput(_term)
+    },
+    onClear,
+    placeholder: formatMessage(messages.costCenter),
+    value: costCenterTextInput,
+  }
+
+  return <AutocompleteInput input={input} options={options} />
+}
+
+export default CostCenterAutocomplete

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -4,7 +4,7 @@ import { AutocompleteInput } from 'vtex.styleguide'
 import { useIntl } from 'react-intl'
 
 import { messages } from './customers-admin'
-import GET_COST from '../queries/costCentersByOrg.gql'
+import GET_COST_CENTER_BY_ORG from '../queries/costCentersByOrg.gql'
 
 interface Props {
   onChange: (value: { value: string | null; label: string }) => void
@@ -25,7 +25,7 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
   const [debouncedSearchTerm, setDebouncedSearchTerm] =
     useState(costCenterTextInput)
 
-  const { data, loading, refetch } = useQuery(GET_COST, {
+  const { data, loading, refetch } = useQuery(GET_COST_CENTER_BY_ORG, {
     variables: {
       ...initialState,
       id: organizationId,

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -63,6 +63,7 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
   }, [debouncedSearchTerm])
 
   const options = {
+    maxHeight: 200,
     onSelect: onChange,
     loading,
     value: data?.getCostCentersByOrganizationId?.data?.map(

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -93,7 +93,6 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
     }
   }, [data])
 
-
   const onClear = useCallback(() => {
     setTerm('')
 
@@ -125,7 +124,6 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
       onClear()
     }
   }, [term])
-
 
   const input = useMemo(
     () => ({

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useMemo, useCallback } from 'react'
 import { useQuery } from 'react-apollo'
 import { AutocompleteInput } from 'vtex.styleguide'
 import { useIntl } from 'react-intl'
@@ -24,79 +24,103 @@ interface Props {
 const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
   const { formatMessage } = useIntl()
   const [term, setTerm] = useState('')
-  const [hasChanged, setHasChanged] = useState(false)
-  const [values, setValues] = useState([] as any)
+  const [debouncedTerm, setDebouncedTerm] = useState(term)
+
+  const [values, setValues] = useState<Array<{ value: string; label: string }>>(
+    []
+  )
+
   const { data, loading, refetch } = useQuery(GET_ORGANIZATIONS, {
     variables: initialState,
     ssr: false,
     notifyOnNetworkStatusChange: true,
   })
 
-  const { data: organization } = useQuery(GET_ORGANIZATION_BY_ID, {
-    variables: { id: organizationId },
-    ssr: false,
-    fetchPolicy: 'network-only',
-    notifyOnNetworkStatusChange: true,
-    skip: !organizationId,
-  })
-
-  const options = {
-    onSelect: (value: any) => onChange(value),
-    loading,
-    value: values,
-  }
-
-  const onClear = () => {
-    if (!hasChanged) return
-    setTerm('')
-    onChange({ value: null, label: '' })
-  }
+  const { data: organization, loading: orgLoading } = useQuery(
+    GET_ORGANIZATION_BY_ID,
+    {
+      variables: { id: organizationId },
+      ssr: false,
+      fetchPolicy: 'network-only',
+      notifyOnNetworkStatusChange: true,
+      skip: !organizationId,
+    }
+  )
 
   useEffect(() => {
-    if (!organization) {
-      return
+    const handler = setTimeout(() => {
+      setDebouncedTerm(term)
+    }, 500) // 500ms delay
+
+    return () => clearTimeout(handler)
+  }, [term])
+
+  useEffect(() => {
+    if (debouncedTerm.length > 2) {
+      refetch({
+        ...initialState,
+        search: debouncedTerm,
+      })
+    } else if (debouncedTerm === '') {
+      refetch({
+        ...initialState,
+        search: '',
+      })
     }
+  }, [debouncedTerm, refetch])
 
-    const { name, id } = organization.getOrganizationById
+  useEffect(() => {
+    // eslint-disable-next-line vtex/prefer-early-return
+    if (organization?.getOrganizationById) {
+      const { name, id } = organization.getOrganizationById
 
-    setTerm(name)
-    setHasChanged(true)
-    onChange({ value: id, label: name })
-  }, [organization])
+      setTerm(name)
+
+      onChange({ value: id, label: name })
+    }
+  }, [organization, onChange])
 
   useEffect(() => {
     if (data?.getOrganizations?.data) {
       setValues(
-        data.getOrganizations.data.map((item: any) => {
-          return {
+        data.getOrganizations.data.map(
+          (item: { id: string; name: string }) => ({
             value: item.id,
             label: item.name,
-          }
-        })
+          })
+        )
       )
     }
   }, [data])
 
-  useEffect(() => {
-    if (term && term.length > 2) {
-      setHasChanged(true)
-      refetch({
-        ...initialState,
-        search: term,
-      })
-    } else if (term === '') {
-      onClear()
-    }
-  }, [term])
+  const onClear = useCallback(() => {
+    setTerm('')
 
-  const input = {
-    onChange: (_term: string) => {
-      setTerm(_term)
-    },
-    onClear,
-    placeholder: formatMessage(messages.searchOrganizations),
-    value: term,
-  }
+    refetch({
+      ...initialState,
+      search: '',
+    })
+    onChange({ value: null, label: '' })
+  }, [onChange, refetch])
+
+  const options = useMemo(
+    () => ({
+      onSelect: onChange,
+      loading,
+      value: values,
+    }),
+    [loading, values, onChange, orgLoading]
+  )
+
+  const input = useMemo(
+    () => ({
+      onChange: (_term: string) => setTerm(_term),
+      onClear,
+      placeholder: formatMessage(messages.searchOrganizations),
+      value: term,
+    }),
+    [term, onClear, formatMessage]
+  )
 
   return <AutocompleteInput input={input} options={options} />
 }

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -70,14 +70,14 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
   }, [debouncedTerm, refetch])
 
   useEffect(() => {
-    // eslint-disable-next-line vtex/prefer-early-return
-    if (organization?.getOrganizationById) {
-      const { name, id } = organization.getOrganizationById
-
-      setTerm(name)
-
-      onChange({ value: id, label: name })
+    if (!organization?.getOrganizationById) {
+      return
     }
+
+    const { name, id } = organization.getOrganizationById
+
+    setTerm(name)
+    onChange({ value: id, label: name })
   }, [organization, onChange])
 
   useEffect(() => {

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -115,7 +115,6 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
 
   useEffect(() => {
     if (term && term.length > 1) {
-      setHasChanged(true)
       refetch({
         ...initialState,
         search: term,

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -6,6 +6,7 @@ import { useIntl } from 'react-intl'
 import { messages } from './customers-admin'
 import GET_ORGANIZATIONS from '../queries/listOrganizations.gql'
 import GET_ORGANIZATION_BY_ID from '../queries/getOrganization.graphql'
+import { SEARCH_TERM_DELAY_MS } from '../constants/debounceDelay'
 
 const initialState = {
   status: ['active', 'on-hold', 'inactive'],
@@ -50,7 +51,7 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
   useEffect(() => {
     const handler = setTimeout(() => {
       setDebouncedTerm(term)
-    }, 500) // 500ms delay
+    }, SEARCH_TERM_DELAY_MS) // 500ms delay
 
     return () => clearTimeout(handler)
   }, [term])

--- a/react/components/OrganizationsAutocomplete.tsx
+++ b/react/components/OrganizationsAutocomplete.tsx
@@ -105,6 +105,7 @@ const OrganizationsAutocomplete = ({ onChange, organizationId }: Props) => {
 
   const options = useMemo(
     () => ({
+      maxHeight: 250,
       onSelect: onChange,
       loading,
       value: values,

--- a/react/components/customers-admin.tsx
+++ b/react/components/customers-admin.tsx
@@ -20,6 +20,7 @@ import GET_COST from '../queries/costCentersByOrg.gql'
 import GET_ORGANIZATIONS from '../queries/getOrganizationsByEmail.graphql'
 import ADD_USER from '../mutations/addUser.gql'
 import DELETE_USER from '../mutations/deleteUser.gql'
+import CostCenterAutocomplete from './CostCentersAutocomplete'
 
 export const messages = defineMessages({
   b2bInfo: {
@@ -455,15 +456,22 @@ const UserEdit: FC<any> = (props: any) => {
             )}
 
             {state.orgId && (
-              <div className="mb5">
-                <Dropdown
-                  label={formatMessage(messages.costCenter)}
-                  options={optionsCost}
-                  value={state.costId}
-                  onChange={(_: any, costId: string) => {
-                    setState({ ...state, costId })
-                  }}
-                />
+              <div className="mb5 w-100">
+                <div className="flex">
+                  <div className="w-100">
+                    <label className="h-100">
+                      <span className="db mt0 mb3 c-on-base t-small">
+                        {formatMessage(messages.costCenter)}
+                      </span>
+                      <CostCenterAutocomplete
+                        organizationId={state.orgId}
+                        onChange={(event) => {
+                          setState({ ...state, costId: event.value })
+                        }}
+                      />
+                    </label>
+                  </div>
+                </div>
               </div>
             )}
 

--- a/react/constants/debounceDelay.ts
+++ b/react/constants/debounceDelay.ts
@@ -1,0 +1,1 @@
+export const SEARCH_TERM_DELAY_MS = 500

--- a/react/package.json
+++ b/react/package.json
@@ -18,7 +18,7 @@
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
     "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.23.0/public/@types/vtex.storefront-permissions",
     "vtex.storefront-permissions-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions-components@0.2.0/public/@types/vtex.storefront-permissions-components",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.13/public/@types/vtex.styleguide"
   },
   "dependencies": {
     "faker": "^4.1.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -500,9 +500,9 @@ typescript@3.9.7:
   version "1.23.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.23.0/public/@types/vtex.storefront-permissions#2a12e48a1b630d6d9cd64115572bcae55a7aa756"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide":
-  version "9.146.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.3/public/@types/vtex.styleguide#05558160f29cd8f4aefe419844a4bd66e2b3fdbb"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.13/public/@types/vtex.styleguide":
+  version "9.146.13"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.13/public/@types/vtex.styleguide#f4ccbc54621bf5114ddd115b6032ae320f2eba55"
 
 zen-observable-ts@^0.8.21:
   version "0.8.21"


### PR DESCRIPTION
What problem is this solving?
Before, it was not possible to show more than 25 options at the dropdown cost center

This change might be motivated by experience from user, enabling a better visualization of organizations

How to test it?
In the admin panel, follow these navigation steps:

1. Select the "Applications" menu.
2. From the opened menu, select "B2B Customers."
3. Add a new customer.
4. Field the access profile.
5. Select the organization.
6. After than select the cost center

[Workspace](https://josmarjr--b2bstore005.myvtex.com/admin/b2b-customers)

Screenshots or example usage:
<img width="1430" alt="Screenshot 2024-09-12 at 10 50 09" src="https://github.com/user-attachments/assets/2eb143f1-dbad-4d7c-a887-e45429fe6f9b">

https://github.com/user-attachments/assets/4350fc27-d5c5-4982-a6dc-0ffae968b6fd

Describe alternatives you've considered, if any.
Related to / Depends on
How does this PR make you feel? [🔗](http://giphy.com/)
![](put .gif link here - can be found under "advanced" on giphy)
