### PR TITLE
Changed cost center input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Changed cost center autocomplet to give suggestions based on the selected organizations
+
 ## [0.4.0] - 2024-09-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- Changed cost center autocomplet to give suggestions based on the selected organizations
+- Changed cost center autocomplete to give suggestions based on the selected organizations
 
 ## [0.4.0] - 2024-09-26
 

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react'
 import { useQuery } from 'react-apollo'
 import { useIntl } from 'react-intl'
 import { EXPERIMENTAL_Select } from 'vtex.styleguide'
-import { messages } from './customers-admin'
 
+import { messages } from './customers-admin'
 import GET_COST_CENTER_BY_ORG from '../queries/costCentersByOrg.gql'
 import { SEARCH_TERM_DELAY_MS } from '../constants/debounceDelay'
 
@@ -44,9 +44,9 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
       })
     ) || []
 
-    const handleSearchInputChange = (searchInput: string | null) => {
-      setCostCenterTextInput(searchInput ?? '') 
-    }
+  const handleSearchInputChange = (searchInput: string | null) => {
+    setCostCenterTextInput(searchInput ?? '')
+  }
 
   useEffect(() => {
     const handler = setTimeout(() => {
@@ -75,7 +75,9 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
     }
   }, [debouncedSearchTerm])
 
-  const handleChange = (selectedOption: { value: string | null; label: string } | null) => {
+  const handleChange = (
+    selectedOption: { value: string | null; label: string } | null
+  ) => {
     if (!selectedOption || !selectedOption.value) {
       setCostCenterTextInput('')
       refetch({
@@ -84,6 +86,7 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
         search: '',
       })
     }
+
     onChange(selectedOption ?? { value: null, label: '' })
   }
 

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { useQuery } from 'react-apollo'
-
 import { useIntl } from 'react-intl'
 import { EXPERIMENTAL_Select } from 'vtex.styleguide'
 import { messages } from './customers-admin'
+
 import GET_COST_CENTER_BY_ORG from '../queries/costCentersByOrg.gql'
 import { SEARCH_TERM_DELAY_MS } from '../constants/debounceDelay'
 
@@ -44,11 +44,8 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
       })
     ) || []
 
-  const handleSearchInputChange = (debouncedSearchTerm: string) => {
-    if (!debouncedSearchTerm.trim()) {
-      setCostCenterTextInput(debouncedSearchTerm)
-    }
-    setCostCenterTextInput(debouncedSearchTerm)
+  const handleSearchInputChange = (serachInput: string) => {
+    setCostCenterTextInput(serachInput)
 
 }
 
@@ -75,7 +72,7 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
   }, [debouncedSearchTerm])
 
   const handleChange = (selectedOption: { value: string | null; label: string } | null) => {
-    onChange(selectedOption || { value: null, label: '' }) 
+    onChange(selectedOption ?? { value: null, label: '' }) 
   }
 
   return (
@@ -86,6 +83,7 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
       options={options}
       placeholder={formatMessage(messages.costCenter)}
       multi={false}
+      valuesMaxHeight={200}
     />
   )
 }

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { useQuery } from 'react-apollo'
-import { AutocompleteInput } from 'vtex.styleguide'
-import { useIntl } from 'react-intl'
 
+import { useIntl } from 'react-intl'
+import { EXPERIMENTAL_Select } from 'vtex.styleguide'
 import { messages } from './customers-admin'
 import GET_COST_CENTER_BY_ORG from '../queries/costCentersByOrg.gql'
 import { SEARCH_TERM_DELAY_MS } from '../constants/debounceDelay'
@@ -36,10 +36,21 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
     skip: !organizationId,
   })
 
-  const onClear = () => {
-    setCostCenterTextInput('')
-    onChange({ value: null, label: '' })
-  }
+  const options =
+    data?.getCostCentersByOrganizationId?.data?.map(
+      (costCenter: { id: string; name: string }) => ({
+        value: costCenter.id,
+        label: costCenter.name,
+      })
+    ) || []
+
+  const handleSearchInputChange = (debouncedSearchTerm: string) => {
+    if (!debouncedSearchTerm.trim()) {
+      setCostCenterTextInput(debouncedSearchTerm)
+    }
+    setCostCenterTextInput(debouncedSearchTerm)
+
+}
 
   useEffect(() => {
     const handler = setTimeout(() => {
@@ -59,32 +70,24 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
         search: debouncedSearchTerm,
       })
     } else if (debouncedSearchTerm === '') {
-      onClear()
+      onChange({ value: null, label: '' })
     }
   }, [debouncedSearchTerm])
 
-  const options = {
-    maxHeight: 200,
-    onSelect: onChange,
-    loading,
-    value: data?.getCostCentersByOrganizationId?.data?.map(
-      (costCenter: { id: string; name: string }) => ({
-        value: costCenter.id,
-        label: costCenter.name,
-      })
-    ),
+  const handleChange = (selectedOption: { value: string | null; label: string } | null) => {
+    onChange(selectedOption || { value: null, label: '' }) 
   }
 
-  const input = {
-    onChange: (_term: string) => {
-      setCostCenterTextInput(_term)
-    },
-    onClear,
-    placeholder: formatMessage(messages.costCenter),
-    value: costCenterTextInput,
-  }
-
-  return <AutocompleteInput input={input} options={options} />
+  return (
+    <EXPERIMENTAL_Select
+      onSearchInputChange={handleSearchInputChange}
+      onChange={handleChange}
+      loading={loading}
+      options={options}
+      placeholder={formatMessage(messages.costCenter)}
+      multi={false}
+    />
+  )
 }
 
 export default CostCenterAutocomplete

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -44,10 +44,9 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
       })
     ) || []
 
-  const handleSearchInputChange = (serachInput: string) => {
-    setCostCenterTextInput(serachInput)
-
-}
+    const handleSearchInputChange = (searchInput: string | null) => {
+      setCostCenterTextInput(searchInput ?? '') 
+    }
 
   useEffect(() => {
     const handler = setTimeout(() => {
@@ -67,12 +66,25 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
         search: debouncedSearchTerm,
       })
     } else if (debouncedSearchTerm === '') {
+      refetch({
+        ...initialState,
+        id: organizationId,
+        search: '',
+      })
       onChange({ value: null, label: '' })
     }
   }, [debouncedSearchTerm])
 
   const handleChange = (selectedOption: { value: string | null; label: string } | null) => {
-    onChange(selectedOption ?? { value: null, label: '' }) 
+    if (!selectedOption || !selectedOption.value) {
+      setCostCenterTextInput('')
+      refetch({
+        ...initialState,
+        id: organizationId,
+        search: '',
+      })
+    }
+    onChange(selectedOption ?? { value: null, label: '' })
   }
 
   return (
@@ -84,6 +96,7 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
       placeholder={formatMessage(messages.costCenter)}
       multi={false}
       valuesMaxHeight={200}
+      claerable={true}
     />
   )
 }

--- a/react/components/CostCentersAutocomplete.tsx
+++ b/react/components/CostCentersAutocomplete.tsx
@@ -66,11 +66,6 @@ const CostCenterAutocomplete = ({ onChange, organizationId }: Props) => {
         search: debouncedSearchTerm,
       })
     } else if (debouncedSearchTerm === '') {
-      refetch({
-        ...initialState,
-        id: organizationId,
-        search: '',
-      })
       onChange({ value: null, label: '' })
     }
   }, [debouncedSearchTerm])


### PR DESCRIPTION
Changed the component of the cost center dropdown (when adding a new user role) so that it can display all cost centers associated to the chosen organization before the user starts typing (requested by a client)

Test instructions:

- In B2B Customers > New > Add New add the role and organization and test the cost center dropdown;
- It should: suggest all cost centers related to that organization, allow you to type to search for a desired cost center, successfully clear the search.