### PR TITLE
chore: update dependency major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update dependency major version
+
 ## [0.5.0] - 2025-01-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- Update dependency major version
+- Update dependency major version. If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
+    - vtex.b2b-admin-customers@1.x
+    - vtex.b2b-checkout-settings@2.x
+    - vtex.b2b-my-account@1.x
+    - vtex.b2b-orders-history@1.x
+    - vtex.b2b-organizations@2.x
+    - vtex.b2b-organizations-graphql@1.x
+    - vtex.b2b-quotes@2.x
+    - vtex.b2b-quotes-graphql@3.x
+    - vtex.b2b-suite@1.x
+    - vtex.b2b-theme@4.x
+    - vtex.storefront-permissions@2.x
+    - vtex.storefront-permissions-ui@2.x
 
 ## [0.5.0] - 2025-01-16
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "vtex.styleguide": "9.x",
     "vtex.admin-customers-graphql": "3.x",
-    "vtex.b2b-organizations-graphql": "0.x",
-    "vtex.storefront-permissions": "1.x"
+    "vtex.b2b-organizations-graphql": "1.x",
+    "vtex.storefront-permissions": "2.x"
   },
   "builders": {
     "react": "3.x",


### PR DESCRIPTION
**What problem is this solving?**

Update major dependencies.

**How should this be manually tested?**

The new major versions for the following apps must be installed in other to test (which can be done only after all PRs updating versions are merged):
```
vtex.b2b-organizations-graphql@1.x
vtex.b2b-quotes-graphql@3.x
vtex.storefront-permissions@2.x
vtex.storefront-permissions-ui@2.x
vtex.storefront-permissions-components@1.x
vtex.b2b-quotes@2.x
vtex.b2b-organizations@2.x
vtex.b2b-checkout-settings@2.x
vtex.b2b-admin-customers@1.x
vtex.b2b-theme@4.x
vtex.b2b-orders-history@1.x
vtex.b2b-my-account@1.x
vtex.b2b-suite@1.x
```